### PR TITLE
Direct tls

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,7 +987,7 @@ const sql = postgres('postgres://username:password@host:port/database', {
   database             : '',            // Name of database to connect to
   username             : '',            // Username of database user
   password             : '',            // Password of database user
-  ssl                  : false,         // true, prefer, require, tls.connect options
+  ssl                  : false,         // true, prefer, require, direct, tls.connect options
   max                  : 10,            // Max number of connections
   max_lifetime         : null,          // Max lifetime in seconds (more info below)
   idle_timeout         : 0,             // Idle connection timeout in seconds

--- a/src/connection.js
+++ b/src/connection.js
@@ -354,12 +354,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         socket = tls.connect({
             socket,
             servername: net.isIP(socket.host) ? undefined : socket.host,
-            ...(ssl === 'direct'
-                    ? { rejectUnauthorized: false }
-                    : typeof ssl === 'object'
-                        ? ssl
-                        : {}
-            )
+            rejectUnauthorized: false
         })
         socket.on('secureConnect', connected)
         socket.on('error', error)

--- a/src/connection.js
+++ b/src/connection.js
@@ -336,7 +336,11 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     if (options.socket)
       return ssl ? secure() : connected()
 
-    socket.on('connect', ssl === 'direct' ? directTLS : ssl ? secure : connected)
+    if (ssl === 'direct') {
+      socket.on('connect', directTLS)
+    } else {
+      socket.on('connect', ssl ? secure : connected)
+    }
 
     if (options.path)
       return socket.connect(options.path)

--- a/src/connection.js
+++ b/src/connection.js
@@ -336,7 +336,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
     if (options.socket)
       return ssl ? secure() : connected()
 
-    socket.on('connect', ssl ? secure : connected)
+    socket.on('connect', ssl === 'direct' ? directTLS : ssl ? secure : connected)
 
     if (options.path)
       return socket.connect(options.path)
@@ -348,6 +348,24 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
 
     hostIndex = (hostIndex + 1) % port.length
   }
+
+    function directTLS() {
+        socket.removeAllListeners()
+        socket = tls.connect({
+            socket,
+            servername: net.isIP(socket.host) ? undefined : socket.host,
+            ...(ssl === 'direct'
+                    ? { rejectUnauthorized: false }
+                    : typeof ssl === 'object'
+                        ? ssl
+                        : {}
+            )
+        })
+        socket.on('secureConnect', connected)
+        socket.on('error', error)
+        socket.on('close', closed)
+        socket.on('drain', drain)
+    }
 
   function reconnect() {
     setTimeout(connect, closedDate ? closedDate + delay - performance.now() : 0)

--- a/src/connection.js
+++ b/src/connection.js
@@ -358,6 +358,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
         socket = tls.connect({
             socket,
             servername: net.isIP(socket.host) ? undefined : socket.host,
+            ALPNProtocols: ['postgresql'],
             rejectUnauthorized: false
         })
         socket.on('secureConnect', connected)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -44,7 +44,7 @@ interface BaseOptions<T extends Record<string, postgres.PostgresType>> {
    * How to deal with ssl (can be a tls.connect option object)
    * @default false
   */
-  ssl: 'require' | 'allow' | 'prefer' | 'verify-full' | boolean | object;
+  ssl: 'require' | 'allow' | 'prefer' | 'verify-full' | 'direct' | boolean | object;
   /**
    * Max number of connections
    * @default 10


### PR DESCRIPTION
Added support for "direct TLS" introduced in Postgres 17+ (https://www.postgresql.org/docs/release/17.0/).

To connect with the new mode use: `ssl: 'direct'`.
